### PR TITLE
feat(config): 添加对 JSON5 和 YAML 配置文件的支持

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Claude Code settings.json中key自动配置工具，方便API_KEY、AUTH_TOKEN�
 - 📝 **友好提示** - 详细的错误信息和操作指导
 - 🎯 **智能识别** - 自动识别当前使用的配置
 - 🛡️ **数据保护** - 敏感信息脱敏显示
+- 📄 **多格式支持** - 支持 JSON、JSON5、YAML 配置文件
 
 ## 安装
 
@@ -47,7 +48,11 @@ ccapi set
 
 ### 3. 自定义API配置文件格式
 
-创建一个`api.json`文件，格式如下：
+现在支持多种配置文件格式：**JSON、JSON5、YAML**。
+
+创建一个配置文件（如 `api.json`、`api.yaml`、`api.jsonc` 或 `api.json5`），格式如下：
+
+**JSON 格式示例：**
 
 ```json
 {
@@ -71,6 +76,45 @@ ccapi set
       "claude-3-5-haiku-20241022",
       "claude-3-haiku-20240307"
     ]
+  }
+}
+```
+
+**YAML 格式示例：**
+
+```yaml
+openrouter:
+  url: "https://api.openrouter.ai"
+  token: "your-auth-token"
+  model: "claude-sonnet-4-20250514"
+  fast: "claude-3-5-haiku-20241022"
+  timeout: 120000
+  tokens: 20000
+
+multimodel:
+  url: "https://api.example.com"
+  key: "your-api-key"
+  model:
+    - "claude-sonnet-4-20250514"
+    - "claude-3-5-haiku-20241022"
+    - "claude-3-opus-20240229"
+  fast:
+    - "claude-3-5-haiku-20241022"
+    - "claude-3-haiku-20240307"
+```
+
+**JSON5 格式示例（支持注释）：**
+
+```json5
+{
+  // OpenRouter 配置
+  "openrouter": {
+    "url": "https://api.openrouter.ai",
+    "token": "your-auth-token",
+    "model": "claude-sonnet-4-20250514",  // 默认模型
+    "fast": "claude-3-5-haiku-20241022",  // 快速模型
+    "timeout": 120000,  // 请求超时时间
+    "tokens": 20000  // 最大输出令牌数
   }
 }
 ```

--- a/README_EN.md
+++ b/README_EN.md
@@ -11,6 +11,7 @@ Claude Code settings.json key auto-configuration tool for easy API_KEY and AUTH_
 - 📝 **User-friendly Prompts** - Detailed error messages and operation guidance
 - 🎯 **Smart Recognition** - Automatically identify the currently used configuration
 - 🛡️ **Data Protection** - Sensitive information is masked in display
+- 📄 **Multi-format Support** - Supports JSON, JSON5, YAML configuration files
 
 ## Installation
 
@@ -47,7 +48,11 @@ ccapi set
 
 ### 3. Custom API Configuration File Format
 
-Create an `api.json` file with the following format:
+Now supports multiple configuration file formats: **JSON, JSON5, YAML**.
+
+Create a configuration file (such as `api.json`, `api.yaml`, `api.jsonc`, or `api.json5`) with the following format:
+
+**JSON Format Example:**
 
 ```json
 {
@@ -71,6 +76,45 @@ Create an `api.json` file with the following format:
       "claude-3-5-haiku-20241022",
       "claude-3-haiku-20240307"
     ]
+  }
+}
+```
+
+**YAML Format Example:**
+
+```yaml
+openrouter:
+  url: "https://api.openrouter.ai"
+  token: "your-auth-token"
+  model: "claude-sonnet-4-20250514"
+  fast: "claude-3-5-haiku-20241022"
+  timeout: 120000
+  tokens: 20000
+
+multimodel:
+  url: "https://api.example.com"
+  key: "your-api-key"
+  model:
+    - "claude-sonnet-4-20250514"
+    - "claude-3-5-haiku-20241022"
+    - "claude-3-opus-20240229"
+  fast:
+    - "claude-3-5-haiku-20241022"
+    - "claude-3-haiku-20240307"
+```
+
+**JSON5 Format Example (supports comments):**
+
+```json5
+{
+  // OpenRouter configuration
+  "openrouter": {
+    "url": "https://api.openrouter.ai",
+    "token": "your-auth-token",
+    "model": "claude-sonnet-4-20250514",  // default model
+    "fast": "claude-3-5-haiku-20241022",  // fast model
+    "timeout": 120000,  // request timeout
+    "tokens": 20000  // max output tokens
   }
 }
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,19 @@
 {
   "name": "@4xian/ccapi",
-  "version": "1.0.1",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@4xian/ccapi",
-      "version": "1.0.1",
+      "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
         "commander": "^11.1.0",
-        "fs-extra": "^11.2.0"
+        "fs-extra": "^11.2.0",
+        "js-yaml": "^4.1.0",
+        "json5": "^2.2.3"
       },
       "bin": {
         "ccapi": "bin/ccapi"
@@ -517,6 +519,12 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "http://repo.nju.edu.cn/npm/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmmirror.com/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -753,6 +761,30 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "*"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "http://repo.nju.edu.cn/npm/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "http://repo.nju.edu.cn/npm/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/jsonfile": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
   "dependencies": {
     "chalk": "^4.1.2",
     "commander": "^11.1.0",
-    "fs-extra": "^11.2.0"
+    "fs-extra": "^11.2.0",
+    "js-yaml": "^4.1.0",
+    "json5": "^2.2.3"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^25.0.7",

--- a/src/commands/list.js
+++ b/src/commands/list.js
@@ -1,6 +1,6 @@
 const chalk = require('chalk');
 const { validateConfig } = require('../utils/config');
-const { readJsonFile } = require('../utils/file');
+const { readConfigFile } = require('../utils/file');
 const { validateApiConfig, validateSettingsConfig } = require('../utils/validator');
 const { CLAUDE_ENV_KEYS, ERROR_MESSAGES } = require('../constants');
 
@@ -137,14 +137,14 @@ async function listCommand() {
     const config = await validateConfig();
 
     // 读取API配置文件
-    const apiConfig = await readJsonFile(config.apiConfigPath);
+    const apiConfig = await readConfigFile(config.apiConfigPath);
     if (!validateApiConfig(apiConfig)) {
       console.error(chalk.red('错误:'), 'api.json文件格式不正确');
       return;
     }
 
     // 读取settings.json文件
-    const settingsData = await readJsonFile(config.settingsPath);
+    const settingsData = await readConfigFile(config.settingsPath);
     if (!validateSettingsConfig(settingsData)) {
       console.error(chalk.red('错误:'), 'settings.json文件格式不正确');
       return;

--- a/src/commands/use.js
+++ b/src/commands/use.js
@@ -1,6 +1,6 @@
 const chalk = require('chalk');
 const { validateConfig } = require('../utils/config');
-const { readJsonFile, writeJsonFile, backupFile } = require('../utils/file');
+const { readConfigFile, writeConfigFile, backupFile } = require('../utils/file');
 const { validateApiConfig, validateSettingsConfig, validateConfigName } = require('../utils/validator');
 const { CLAUDE_ENV_KEYS, ERROR_MESSAGES, SUCCESS_MESSAGES } = require('../constants');
 
@@ -110,7 +110,7 @@ async function useCommand(configName, options = {}) {
     const config = await validateConfig();
 
     // 读取API配置文件
-    const apiConfig = await readJsonFile(config.apiConfigPath);
+    const apiConfig = await readConfigFile(config.apiConfigPath);
     if (!validateApiConfig(apiConfig)) {
       console.error(chalk.red('错误:'), 'api.json文件格式不正确');
       return;
@@ -124,7 +124,7 @@ async function useCommand(configName, options = {}) {
     }
 
     // 读取settings.json文件
-    const settingsData = await readJsonFile(config.settingsPath);
+    const settingsData = await readConfigFile(config.settingsPath);
     if (!validateSettingsConfig(settingsData)) {
       console.error(chalk.red('错误:'), 'settings.json文件格式不正确');
       return;
@@ -179,7 +179,7 @@ async function useCommand(configName, options = {}) {
     const updatedSettings = updateSettingsEnv(settingsData, targetConfig);
 
     // 保存更新后的settings.json
-    await writeJsonFile(config.settingsPath, updatedSettings);
+    await writeConfigFile(config.settingsPath, updatedSettings);
 
     // 显示成功信息
     console.log();

--- a/src/constants.js
+++ b/src/constants.js
@@ -23,6 +23,7 @@ const ERROR_MESSAGES = {
   SETTINGS_NOT_FOUND: 'settings.json 文件不存在，请检查路径设置',
   API_CONFIG_NOT_FOUND: 'api.json 文件不存在，请检查路径设置',
   INVALID_JSON: 'JSON文件格式错误',
+  INVALID_YAML: 'YAML文件格式错误',
   CONFIG_NAME_NOT_FOUND: '指定的配置名称不存在',
   SAME_CONFIG: '当前已使用该配置',
   BACKUP_FAILED: 'settings.json 备份失败'

--- a/src/utils/config-reader.js
+++ b/src/utils/config-reader.js
@@ -1,0 +1,149 @@
+const fs = require('fs-extra');
+const path = require('path');
+const JSON5 = require('json5');
+const yaml = require('js-yaml');
+const { ERROR_MESSAGES } = require('../constants');
+
+/**
+ * 支持的配置文件格式
+ */
+const SUPPORTED_FORMATS = {
+  '.json': 'json',   // 支持 JSON
+  '.jsonc': 'json5',  // 支持 JSONC
+  '.json5': 'json5',  // 支持 JSON5
+  '.yaml': 'yaml',   // 支持 YAML
+  '.yml': 'yaml'     // 支持 YML
+};
+
+/**
+ * 根据文件扩展名获取格式类型
+ */
+function getConfigFormat(filePath) {
+  const ext = path.extname(filePath).toLowerCase();
+  return SUPPORTED_FORMATS[ext] || null;
+}
+
+/**
+ * 读取配置文件（支持 JSON、JSON5、JSONC、YAML 格式）
+ */
+async function readConfigFile(filePath) {
+  try {
+    if (!await fs.pathExists(filePath)) {
+      throw new Error(`文件不存在: ${filePath}`);
+    }
+    
+    const content = await fs.readFile(filePath, 'utf8');
+    const format = getConfigFormat(filePath);
+    
+    if (!format) {
+      throw new Error(`不支持的配置文件格式: ${path.extname(filePath)}`);
+    }
+    
+    let parsed;
+    switch (format) {
+      case 'json':
+        parsed = JSON.parse(content);
+        break;
+      case 'json5':
+        parsed = JSON5.parse(content);
+        break;
+      case 'yaml':
+        parsed = yaml.load(content);
+        break;
+      default:
+        throw new Error(`未实现的配置文件格式: ${format}`);
+    }
+    
+    return parsed;
+  } catch (error) {
+    if (error.name === 'JSONError' || error.message.includes('JSON')) {
+      throw new Error(`${ERROR_MESSAGES.INVALID_JSON}: ${filePath} - ${error.message}`);
+    }
+    if (error.name === 'YAMLException') {
+      throw new Error(`${ERROR_MESSAGES.INVALID_YAML}: ${filePath} - ${error.message}`);
+    }
+    throw error;
+  }
+}
+
+/**
+ * 写入配置文件（支持 JSON、JSON5、YAML 格式）
+ */
+async function writeConfigFile(filePath, data) {
+  try {
+    // 确保目录存在
+    await fs.ensureDir(path.dirname(filePath));
+    
+    const format = getConfigFormat(filePath);
+    let content;
+    
+    switch (format) {
+      case 'json':
+        content = JSON.stringify(data, null, 2);
+        break;
+      case 'json5':
+        content = JSON5.stringify(data, null, 2);
+        break;
+      case 'yaml':
+        content = yaml.dump(data, {
+          indent: 2,
+          lineWidth: -1,
+          noRefs: true
+        });
+        break;
+      default:
+        throw new Error(`不支持的配置文件格式: ${path.extname(filePath)}`);
+    }
+    
+    await fs.writeFile(filePath, content, 'utf8');
+  } catch (error) {
+    throw new Error(`写入文件失败: ${filePath} - ${error.message}`);
+  }
+}
+
+/**
+ * 验证路径格式（现在支持多种配置文件格式）
+ */
+function validateConfigPath(filePath) {
+  if (!filePath || typeof filePath !== 'string') {
+    return false;
+  }
+  
+  // 检查是否为绝对路径
+  if (!path.isAbsolute(filePath)) {
+    return false;
+  }
+  
+  // 检查文件扩展名
+  const ext = path.extname(filePath).toLowerCase();
+  return ext in SUPPORTED_FORMATS;
+}
+
+/**
+ * 扩展的路径验证（放宽限制）
+ */
+function validateApiConfigPath(filePath) {
+  if (!filePath || typeof filePath !== 'string') {
+    return false;
+  }
+  
+  // 检查是否为绝对路径
+  if (!path.isAbsolute(filePath)) {
+    return false;
+  }
+  
+  // 检查文件扩展名 - 支持更多格式
+  const ext = path.extname(filePath).toLowerCase();
+  const allowedExtensions = Object.keys(SUPPORTED_FORMATS);
+  
+  return allowedExtensions.includes(ext);
+}
+
+module.exports = {
+  readConfigFile,
+  writeConfigFile,
+  validateConfigPath,
+  validateApiConfigPath,
+  getConfigFormat,
+  SUPPORTED_FORMATS
+};

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -1,4 +1,4 @@
-const { readJsonFile, writeJsonFile, fileExists } = require('./file');
+const { readConfigFile, writeConfigFile, fileExists } = require('./file');
 const { CONFIG_FILE, ERROR_MESSAGES } = require('../constants');
 
 /**
@@ -9,7 +9,7 @@ async function readConfig() {
     if (!await fileExists(CONFIG_FILE)) {
       return {};
     }
-    return await readJsonFile(CONFIG_FILE);
+    return await readConfigFile(CONFIG_FILE);
   } catch (error) {
     throw new Error(`读取配置失败: ${error.message}`);
   }
@@ -20,7 +20,7 @@ async function readConfig() {
  */
 async function writeConfig(config) {
   try {
-    await writeJsonFile(CONFIG_FILE, config);
+    await writeConfigFile(CONFIG_FILE, config);
   } catch (error) {
     throw new Error(`保存配置失败: ${error.message}`);
   }

--- a/src/utils/file.js
+++ b/src/utils/file.js
@@ -1,40 +1,20 @@
 const fs = require('fs-extra');
 const path = require('path');
+const { readConfigFile: readFile, writeConfigFile: writeFile } = require('./config-reader');
 const { ERROR_MESSAGES } = require('../constants');
 
 /**
- * 安全读取JSON文件
+ * 读取配置文件
  */
-async function readJsonFile(filePath) {
-  try {
-    if (!await fs.pathExists(filePath)) {
-      throw new Error(`文件不存在: ${filePath}`);
-    }
-    
-    const content = await fs.readFile(filePath, 'utf8');
-    return JSON.parse(content);
-  } catch (error) {
-    if (error.message.includes('JSON')) {
-      throw new Error(`${ERROR_MESSAGES.INVALID_JSON}: ${filePath}`);
-    }
-    throw error;
-  }
+async function readConfigFile(filePath) {
+  return await readFile(filePath);
 }
 
 /**
- * 安全写入JSON文件
+ * 写入配置文件
  */
-async function writeJsonFile(filePath, data) {
-  try {
-    // 确保目录存在
-    await fs.ensureDir(path.dirname(filePath));
-    
-    // 格式化JSON输出
-    const content = JSON.stringify(data, null, 2);
-    await fs.writeFile(filePath, content, 'utf8');
-  } catch (error) {
-    throw new Error(`写入文件失败: ${filePath} - ${error.message}`);
-  }
+async function writeConfigFile(filePath, data) {
+  return await writeFile(filePath, data);
 }
 
 /**
@@ -76,8 +56,8 @@ function validatePath(filePath) {
 }
 
 module.exports = {
-  readJsonFile,
-  writeJsonFile,
+  readConfigFile,
+  writeConfigFile,
   backupFile,
   fileExists,
   validatePath

--- a/src/utils/validator.js
+++ b/src/utils/validator.js
@@ -1,4 +1,5 @@
 const { validatePath } = require('./file');
+const { validateApiConfigPath } = require('./config-reader');
 
 /**
  * 验证API配置数据结构
@@ -85,11 +86,11 @@ function validateSetCommand(options) {
     };
   }
 
-  // 验证api路径
-  if (api && !validatePath(api)) {
+  // 验证api路径 - 使用放宽的验证
+  if (api && !validateApiConfigPath(api)) {
     return {
       valid: false,
-      error: 'api路径格式错误，请提供绝对路径的api.json文件'
+      error: 'api路径格式错误，请提供绝对路径的配置文件（支持 .json、.json5、.jsonc、.yaml、.yml）'
     };
   }
 


### PR DESCRIPTION
- 添加对 JSON5 和 YAML 格式配置文件的支持
- 更新 `README.md` 和 `README_EN.md` 以包含新格式的示例
- 修改 `src/utils/file.js` 以使用新的配置读取和写入函数
- 添加 `src/utils/config-reader.js` 文件以处理不同格式的配置文件
- 更新 `src/constants.js` 以包含新的错误消息
- 更新 `src/utils/validator.js` 以支持新的配置文件格式
- 更新 `package.json` 和 `package-lock.json` 以添加 `js-yaml` 和 `json5` 依赖

#3 