### PR TITLE
Quote Unix env values safely

### DIFF
--- a/src/utils/env.js
+++ b/src/utils/env.js
@@ -14,6 +14,13 @@ const maxText = 30
 const CONFIG_IDENTIFIER = 'CCAPI_CURRENT_CONFIG'
 
 /**
+ * 安全地将值包裹为 POSIX shell 单引号字符串
+ */
+function shellQuote(value) {
+  return `'${String(value).replace(/'/g, `'\"'\"'`)}'`
+}
+
+/**
  * 获取当前平台类型
  */
 async function getPlatformType() {
@@ -103,7 +110,7 @@ async function setUnixEnvVars(envVars) {
     }
 
     // 构建新的环境变量区域
-    const envLines = ['', startMarker, ...Object.entries(envVars).map(([k, v]) => `export ${k}="${v}"`), endMarker, '']
+    const envLines = ['', startMarker, ...Object.entries(envVars).map(([k, v]) => `export ${k}=${shellQuote(v)}`), endMarker, '']
 
     // 写入配置文件
     const newContent = content.trim() + '\n' + envLines.join('\n')


### PR DESCRIPTION
## What changed

- Added a small POSIX shell quoting helper for Unix environment variable values.
- Switched generated Unix exports from double-quoted interpolation to single-quoted shell-safe values.

## Why

Values such as API keys, auth tokens, proxy URLs, or config names may contain shell-sensitive characters like `$`, backticks, double quotes, single quotes, or newlines. Writing them directly as `export KEY="value"` can cause shell expansion or truncation when `.zshrc` / `.bashrc` is sourced.

This keeps those values literal when the shell config is loaded.

## Validation

- `node -c src/utils/env.js`
- Manually sourced generated exports containing double quotes, `$HOME`, single quotes, backticks, and newlines, and verified the environment values remain unchanged.

Addresses #20
